### PR TITLE
Add DOI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BeetlePalooza-2024
+# BeetlePalooza-2024 [![DOI](https://zenodo.org/badge/797486172.svg)](https://doi.org/10.5281/zenodo.15272136)
 BeetlePalooza collaborative hands-on development event to be held at The Ohio State University August 12-15, 2024.
 
 ![BeetlePalooza preliminary logo](Beetlepalooza-2024-logo.png)


### PR DESCRIPTION
I already added the DOI badge to the [wiki](https://github.com/Imageomics/BeetlePalooza-2024/wiki) for easier reference to the [archive snapshot](https://doi.org/10.5281/zenodo.15272136).

<img width="1264" height="413" alt="Screenshot 2026-03-04 at 12 47 36 PM" src="https://github.com/user-attachments/assets/82bd3bc8-cbbd-4629-9385-4ab7f8c2dbb2" />

Once this is merged I'll archive the repo as we discussed.